### PR TITLE
Fix invalid CPF count

### DIFF
--- a/cpf_inspector.py
+++ b/cpf_inspector.py
@@ -85,9 +85,10 @@ def processar_arquivo(filename, output_filename, show_valid_only, writer):
                             writer.writerow([cpf_formatado, 'VALIDO'])  # Escreve o CPF formatado como válido no arquivo de saída
                         elif output_filename:
                             print("[!] Erro: Não é possível escrever em um arquivo de saída.")
-                    elif not show_valid_only:
+                    else:
                         cpfs_invalidos += 1
-                        print(f"[{total_cpfs}]".ljust(5) + f" {(cpf).ljust(45)}" + "[" + colorama.Fore.RED + "X" + colorama.Style.RESET_ALL + "]")  # Exibe o CPF como inválido
+                        if not show_valid_only:
+                            print(f"[{total_cpfs}]".ljust(5) + f" {(cpf).ljust(45)}" + "[" + colorama.Fore.RED + "X" + colorama.Style.RESET_ALL + "]")  # Exibe o CPF como inválido
                         if writer:
                             writer.writerow([cpf, 'INVALIDO'])  # Escreve o CPF como inválido no arquivo de saída
                         elif output_filename:


### PR DESCRIPTION
## Summary
- increment `cpfs_invalidos` for every invalid CPF
- keep invalid CPF output hidden when `--true` flag is used

## Testing
- `python -m py_compile cpf_inspector.py`

------
https://chatgpt.com/codex/tasks/task_e_6876e2d12b88832090d278cee89f7830